### PR TITLE
remove no-longer supported dropbear option -m

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 SSHD_PORT=2222
 if ! [ -e /tmp/dropbear.pid ]; then
-	dropbear -s -j -k -m -p "$SSHD_PORT" -P /tmp/dropbear.pid -E >/tmp/dropbear.log 2>&1
+	dropbear -s -j -k -p "$SSHD_PORT" -P /tmp/dropbear.pid -E >/tmp/dropbear.log 2>&1
 	err=$?
 	if [ $err -ne 0 ]; then
 		warn "Failed to start SSH server: error code $err"


### PR DESCRIPTION
Newer versions of dropbear no longer support the "-m" option, causing dropbear to fail to start.  This commit removes this option.  It should not impact functionality with earlier versions of dropbear (the "-m" option is only cosmetic as far as I can tell), but I haven't tested it with earlier versions.

cf. https://github.com/random-archer/mkinitcpio-systemd-tool/issues/11